### PR TITLE
feat: Improve symbol docs access on generic paths

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
   "pyyaml>=6.0.2",
   "referencing>=0.36.2",
   "jsonref>=1.1.0",
+  "jsonpath-ng>=1.7.0",
 ]
 classifiers = [
   "Development Status :: 3 - Alpha",
@@ -95,6 +96,7 @@ strict = true
 [[tool.mypy.overrides]]
 module = [
   "jsonref",
+  "jsonpath_ng"
 ]
 ignore_missing_imports = true
 

--- a/src/craft_ls/core.py
+++ b/src/craft_ls/core.py
@@ -101,8 +101,9 @@ def get_validator_and_scan(
             return cast(Validator, MissingTypeCharmcraftValidator()), scanned_tokens
 
         validator = Draft202012Validator(
-            schema={"$ref": "urn:charmcraft:platformcharm"},
-            registry=charmcraft_registry,
+            schema=charmcraft_registry.resolver()
+            .lookup("urn:charmcraft:platformcharm")
+            .contents
         )
         return cast(Validator, validator), scanned_tokens
     return None, scanned_tokens

--- a/src/craft_ls/server.py
+++ b/src/craft_ls/server.py
@@ -138,9 +138,9 @@ def hover(ls: LanguageServer, params: lsp.HoverParams) -> lsp.Hover | None:
     ):
         return None
 
-    # This is needed to get a dereferenced schema we can walk through
-    schema = next(validator.iter_errors({})).schema
-    description = get_description_from_path(path=path, schema=cast(Schema, schema))
+    description = get_description_from_path(
+        path=path, schema=cast(Schema, validator.schema)
+    )
     return lsp.Hover(
         contents=lsp.MarkupContent(
             kind=lsp.MarkupKind.Markdown,

--- a/src/craft_ls/server.py
+++ b/src/craft_ls/server.py
@@ -12,6 +12,7 @@ from pygls.server import LanguageServer
 from craft_ls import __version__
 from craft_ls.core import (
     get_description_from_path,
+    get_description_from_path_snapcraft,
     get_diagnostics,
     get_schema_path_from_token_position,
     get_validator_and_scan,
@@ -138,9 +139,17 @@ def hover(ls: LanguageServer, params: lsp.HoverParams) -> lsp.Hover | None:
     ):
         return None
 
-    description = get_description_from_path(
-        path=path, schema=cast(Schema, validator.schema)
-    )
+    if file_stem != "snapcraft":
+        description = get_description_from_path(
+            path=path, schema=cast(Schema, validator.schema)
+        )
+
+    else:
+        # TODO(snap): Change this once the jsonschema is more query-able.
+        description = get_description_from_path_snapcraft(
+            path=path, schema=cast(Schema, validator.schema)
+        )
+
     return lsp.Hover(
         contents=lsp.MarkupContent(
             kind=lsp.MarkupKind.Markdown,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -93,7 +93,7 @@ def test_get_description_nested_ok() -> None:
     assert description == "The price currency"
 
 
-@given(key=st.text())
+@given(key=st.text(min_size=1))
 @example("something_not_present")
 def test_get_description_unknown_path(key: str) -> None:
     """Assert that we get a default message if the key is not in the schema."""

--- a/uv.lock
+++ b/uv.lock
@@ -36,6 +36,7 @@ wheels = [
 name = "craft-ls"
 source = { editable = "." }
 dependencies = [
+    { name = "jsonpath-ng" },
     { name = "jsonref" },
     { name = "jsonschema" },
     { name = "lsprotocol" },
@@ -62,6 +63,7 @@ unit = [
 
 [package.metadata]
 requires-dist = [
+    { name = "jsonpath-ng", specifier = ">=1.7.0" },
     { name = "jsonref", specifier = ">=1.1.0" },
     { name = "jsonschema", specifier = ">=4.23.0" },
     { name = "lsprotocol", specifier = ">=2023.0.0" },
@@ -104,6 +106,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
+]
+
+[[package]]
+name = "jsonpath-ng"
+version = "1.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ply" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/86/08646239a313f895186ff0a4573452038eed8c86f54380b3ebac34d32fb2/jsonpath-ng-1.7.0.tar.gz", hash = "sha256:f6f5f7fd4e5ff79c785f1573b394043b39849fb2bb47bcead935d12b00beab3c", size = 37838, upload-time = "2024-10-11T15:41:42.404Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/5a/73ecb3d82f8615f32ccdadeb9356726d6cae3a4bbc840b437ceb95708063/jsonpath_ng-1.7.0-py3-none-any.whl", hash = "sha256:f3d7f9e848cba1b6da28c55b1c26ff915dc9e0b1ba7e752a53d6da8d5cbd00b6", size = 30105, upload-time = "2024-11-20T17:58:30.418Z" },
 ]
 
 [[package]]
@@ -205,6 +219,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955, upload-time = "2024-04-20T21:34:42.531Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556, upload-time = "2024-04-20T21:34:40.434Z" },
+]
+
+[[package]]
+name = "ply"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/69/882ee5c9d017149285cab114ebeab373308ef0f874fcdac9beb90e0ac4da/ply-3.11.tar.gz", hash = "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3", size = 159130, upload-time = "2018-02-15T19:01:31.097Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/58/35da89ee790598a0700ea49b2a66594140f44dec458c07e8e3d4979137fc/ply-3.11-py2.py3-none-any.whl", hash = "sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce", size = 49567, upload-time = "2018-02-15T19:01:27.172Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Changes

This PR enables accessing the description under "generic" paths for charmcraft and rockcraft files.

Ex.:

```yaml
# rockcraft.yaml
parts:
  my-custom-part:
    plugin: dump

```

Since `my-custom-part` is obviously not present in the jsonschema, simply traversing the schema looking for the successive keys was not enough if we want to access the `dump` symbol. 

Keys under a generic path need a little more time to fetch (the space to query can be quite large), so we might want to think about some pre-processing step to transform the jsonschema into something more convenient.
The server still feels responsive right now, but we'll probably need it for a snappy autocomplete feature.

Snapcraft does not benefit from this, as the schema structure is way more lax