### PR TITLE
fix: Add schema to no op classes

### DIFF
--- a/src/craft_ls/core.py
+++ b/src/craft_ls/core.py
@@ -175,7 +175,11 @@ def get_snapcraft_validator(tree: Tree) -> Validator:
             )
 
         case _:
-            validator = MissingTypeSnapcraftValidator()
+            validator = MissingTypeSnapcraftValidator(
+                schema=snapcraft_registry.resolver()
+                .lookup("urn:snapcraft:core26")
+                .contents
+            )
 
     return cast(Validator, validator)
 
@@ -194,7 +198,14 @@ def get_validator_from_tree(file_stem: str, tree: Tree) -> Validator | None:
     else:
         # by elimination, file_stem is charmcraft
         if get_charm_type(tree) != "charm":
-            return cast(Validator, MissingTypeCharmcraftValidator())
+            return cast(
+                Validator,
+                MissingTypeCharmcraftValidator(
+                    charmcraft_registry.resolver()
+                    .lookup("urn:charmcraft:platformcharm")
+                    .contents
+                ),
+            )
 
         validator = cast(
             Validator,

--- a/src/craft_ls/types_.py
+++ b/src/craft_ls/types_.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections import deque
+from dataclasses import dataclass
 from typing import Any, Generator, NamedTuple, NewType, TypeAlias
 
 from jsonschema import ValidationError, Validator
@@ -26,11 +27,14 @@ class IndexEntry(NamedTuple):
 DocumentsIndex: TypeAlias = dict[str, IndexEntry]
 
 
+@dataclass
 class MissingTypeCharmcraftValidator:
     """No op implementation.
 
     Used if charmcraft.yaml is missing the 'type' key or is set to 'bundle'.
     """
+
+    schema: Any
 
     def iter_errors(
         self, instance: Any, _schema: Any = None
@@ -47,6 +51,7 @@ class MissingTypeCharmcraftValidator:
 MISSING_TYPE_MSG = "Missing or unsupported 'base' and/or 'build-base' key(s)."
 
 
+@dataclass
 class MissingTypeSnapcraftValidator:
     """No op implementation.
 
@@ -54,6 +59,8 @@ class MissingTypeSnapcraftValidator:
     - missing the 'base' or 'build-base' key
     - using an unsupported base
     """
+
+    schema: Any
 
     def iter_errors(
         self, instance: Any, _schema: Any = None

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -59,12 +59,15 @@ async def test_diagnostic_on_open(client: LanguageClient):
 
 @pytest.mark.asyncio
 async def test_completion_at_root_key(client: LanguageClient):
-    """Verify incomplete keys successfully suggest top-level fields (like confinement)."""
+    """Verify incomplete keys successfully suggest top-level fields (like confinement).
+
+    In addition, we check that we get some minimal level of feature even if we don't have
+    fully determined the schema to use.
+    """
     # Given
     uri = "file:///workspace/snapcraft.yaml"
     text_content = dedent(
         """
-        base: core24
         confi
         """
     )
@@ -81,11 +84,11 @@ async def test_completion_at_root_key(client: LanguageClient):
         )
     )
 
-    # Trigger completion right at the tip of 'confi' at line 1 (+offset 1)) col 5
+    # Trigger completion right at the tip of 'confi' at line 0 (+offset 1)) col 5
     response = await client.text_document_completion_async(
         types.CompletionParams(
             text_document=types.TextDocumentIdentifier(uri=uri),
-            position=types.Position(line=2, character=5),
+            position=types.Position(line=1, character=5),
         )
     )
 


### PR DESCRIPTION
fix #34

Even if we cannot determine the actual schema, we can default to one of them to provide autocompletion and hover